### PR TITLE
Add stack-8.2 and fix compiler error/warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,10 @@ matrix:
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.2.yaml"
+    compiler: ": #stack 8.2.2"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
@@ -93,6 +97,10 @@ matrix:
 
   - env: BUILD=stack ARGS="--resolver lts-7"
     compiler: ": #stack 8.0.1 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-ghc-8.2.yaml"
+    compiler: ": #stack 8.2.2 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/solga/src/Solga.hs
+++ b/solga/src/Solga.hs
@@ -54,7 +54,6 @@ import           Control.Exception.Safe
 import           Control.Monad
 import           Control.Monad.Trans.Resource
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Encode as Aeson
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.Map.Strict as Map
@@ -170,7 +169,7 @@ data OneOfSegs (segs :: [ Symbol ]) next = OneOfSegs { oneOfSegsNext :: next }
 instance (KnownSymbol seg, Router next, Router (OneOfSegs segs next)) => Router (OneOfSegs (seg ': segs) next) where
   tryRoute = tryRouteNext $ \(OneOfSegs next) -> (Seg next :: Seg seg next) :<|> (OneOfSegs next :: OneOfSegs segs next)
 
-instance Router next => Router (OneOfSegs '[] next) where
+instance Router (OneOfSegs '[] next) where
   tryRoute _ = Nothing
 
 -- | The class of types that can be parsed from a path segment.
@@ -283,7 +282,7 @@ class Abbreviated a where
   type Brief a :: *
   type instance Brief a = a
   brief :: Brief a -> a
-  default brief :: a -> a
+  default brief :: Brief a ~ a => Brief a -> a
   brief = id
 
 instance Abbreviated Raw where

--- a/solga/test/Test.hs
+++ b/solga/test/Test.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE QuasiQuotes          #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
@@ -93,7 +94,9 @@ spec = with (return $ serve testAPI) $ do
       resp <- get path
       liftIO $ decode (simpleBody resp) `shouldBe` Just (String seg)
 
+#if __GLASGOW_HASKELL__ < 802
 deriving instance Generic Value
+#endif
 
 instance Arbitrary Value where
   arbitrary = sized arbJSON

--- a/stack-ghc-8.2.yaml
+++ b/stack-ghc-8.2.yaml
@@ -1,0 +1,33 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-11.22
+
+# Local packages, usually specified by relative directory name
+packages:
+- 'solga'
+- 'solga-swagger'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Fixes #9

* Added a yaml file for lts-11.22 which uses ghc-8.2. 
* At the same time I fixed some compiler warnings using -Wall and -Werror
* Ensured that `solga` worked for both versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chpatrick/solga/14)
<!-- Reviewable:end -->
